### PR TITLE
GHC 9.14 support

### DIFF
--- a/anal.cabal
+++ b/anal.cabal
@@ -12,45 +12,46 @@ bug-reports: https://github.com/tonyday567/anal/issues
 synopsis: See readme.md
 description: See readme.md for description.
 build-type: Simple
-tested-with: GHC == 9.6.2 || == 9.8.1
+tested-with: ghc ==9.6.2 || ==9.8.1
 
 source-repository head
-    type: git
-    location: https://github.com/tonyday567/anal
+  type: git
+  location: https://github.com/tonyday567/anal
 
 common ghc-options-stanza
-    ghc-options:
-        -Wall
-        -Wcompat
-        -Widentities
-        -Wincomplete-record-updates
-        -Wincomplete-uni-patterns
-        -Wpartial-fields
-        -Wredundant-constraints
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Widentities
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wpartial-fields
+    -Wredundant-constraints
 
 common ghc2021-stanza
-    default-language: GHC2021
+  default-language: GHC2021
 
 library
-    import: ghc-options-stanza
-    import: ghc2021-stanza
-    hs-source-dirs: src
-    build-depends:
-        , base         >=4.7 && <5
-        , bytestring   >=0.11.3 && <0.13
-        , chart-svg    >=0.6 && <0.7
-        , containers   >=0.6 && <0.8
-        , faker
-        , flatparse    >=0.3.5 && <0.6
-        , markup-parse >=0.1 && <0.2
-        , mealy        >=0.4 && <0.5
-        , numhask      >=0.10 && <0.12
-        , optics-core  >=0.4 && <0.5
-        , prettychart  >=0.2 && <0.3
-        , profunctors  >=5.6.2 && <5.7
-        , text         >=1.2 && <2.2
-        , time         >=1.9 && <1.13
-        , web-rep      >=0.11 && <0.13
-    exposed-modules:
-        Anal
-        Anal.Returns
+  import: ghc-options-stanza
+  import: ghc2021-stanza
+  hs-source-dirs: src
+  build-depends:
+    base >=4.7 && <5,
+    bytestring >=0.11.3 && <0.13,
+    chart-svg >=0.6 && <0.7,
+    containers >=0.6 && <0.8,
+    faker,
+    flatparse >=0.3.5 && <0.6,
+    markup-parse >=0.1 && <0.2,
+    mealy >=0.4 && <0.5,
+    numhask >=0.10 && <0.12,
+    optics-core >=0.4 && <0.5,
+    prettychart >=0.2 && <0.3,
+    profunctors >=5.6.2 && <5.7,
+    text >=1.2 && <2.2,
+    time >=1.9 && <1.13,
+    web-rep >=0.11 && <0.13,
+
+  exposed-modules:
+    Anal
+    Anal.Returns

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 packages:
   anal.cabal
 
+allow-newer: *:base, *:template-haskell

--- a/src/Anal.hs
+++ b/src/Anal.hs
@@ -66,11 +66,10 @@ serve =
   startChartServerWith defaultSocketConfig $
     chartSocketPage Nothing
       & #htmlBody
-      .~ element
-        "div"
-        [Attr "class" "container"]
-        ( element "div" [Attr "class" "row"] $ element "div" [Attr "class" "col"] (element_ "div" [Attr "id" "prettychart"])
-        )
+        .~ element
+          "div"
+          [Attr "class" "container"]
+          (element "div" [Attr "class" "row"] $ element "div" [Attr "class" "col"] (element_ "div" [Attr "id" "prettychart"]))
 
 dayChart :: [Text] -> [(Day, [Double])] -> ChartOptions
 dayChart labels xs = mempty & #chartTree .~ named "day" cs & #hudOptions .~ h
@@ -82,11 +81,11 @@ dayChart labels xs = mempty & #chartTree .~ named "day" cs & #hudOptions .~ h
     h = defaultHudOptions & #axes .~ [xaxis, yaxis] & #frames %~ (<> [Priority 30 $ defaultFrameOptions & #buffer .~ 0.1]) & #legends .~ leg
     leg =
       [ Priority 12 $
-            defaultLegendOptions
-              & over #frame (fmap (set #color white))
-              & set #place PlaceRight
-              & set (#textStyle % #size) 0.15
-              & set #legendCharts (zipWith (\t c -> (t, [c])) labels cs)
+          defaultLegendOptions
+            & over #frame (fmap (set #color white))
+            & set #place PlaceRight
+            & set (#textStyle % #size) 0.15
+            & set #legendCharts (zipWith (\t c -> (t, [c])) labels cs)
       ]
 
 dayAxis :: [Day] -> Priority AxisOptions
@@ -97,14 +96,14 @@ leg' :: [Text] -> [Chart] -> ChartOptions
 leg' labels cs =
   mempty
     & #hudOptions
-    % #legends
-    .~ [ Priority 12 $
+      % #legends
+      .~ [ Priority 12 $
              defaultLegendOptions
                & over #frame (fmap (set #color white))
                & set #place PlaceRight
                & set (#textStyle % #size) 0.15
                & set #legendCharts (zipWith (\t c -> (t, [c])) labels cs)
-       ]
+         ]
 
 -- | line chart with vertical axis, no guideline ticks
 lchart :: Maybe Place -> Colour -> [Double] -> ChartOptions


### PR DESCRIPTION
GHC 9.14 support with allow-newer constraints.

Adds allow-newer constraint for template-haskell to support GHC 9.14 compilation.